### PR TITLE
fix: update context menu on popup control change

### DIFF
--- a/src/background-scripts/background.ts
+++ b/src/background-scripts/background.ts
@@ -134,6 +134,7 @@ function logUnexpected(key: string, value: any) {
         case BSMessageType.SetCurrentActivation: {
             if (isSetActivationRequest(request.payload)) {
                 browserStorage.setCurrentActivation(request.payload.isActivated);
+                contextMenuManager.updateContextMenuBasedOnActivation(request.payload.isActivated);
                 // tab notification done by activaters, so nothing else to do
             } else {
                 logUnexpected('payload', request.payload);
@@ -159,7 +160,10 @@ function logUnexpected(key: string, value: any) {
         }
         case BSMessageType.LoadExtensionData: {
             if (isLoadExtensionDataRequest(request.payload)) {
-                browserStorage.uploadExtensionData(request.payload.data);
+                browserStorage.uploadExtensionData(request.payload.data).then(
+                    (response) =>
+                    contextMenuManager.updateContextMenuBasedOnActivation(response)
+                );
             } else {
                 logUnexpected('payload', request.payload);
             }

--- a/src/background-scripts/non-volatile-browser-storage.ts
+++ b/src/background-scripts/non-volatile-browser-storage.ts
@@ -64,11 +64,11 @@ export interface NonVolatileBrowserStorage {
 
     /**
      * Overrides all extension data stored in non-volatile storage with that present
-     * in data.
+     * in data and returns activation status in data
      * 
      * @param data Data to store into non-volatile storage
      */
-    uploadExtensionData(data: any): void;
+    uploadExtensionData(data: any): Promise<boolean>;
 }
 
 type StoredActivatedState = 1|0;  // type of data the represents data stored in activated state
@@ -183,10 +183,10 @@ class LocalStorage implements NonVolatileBrowserStorage {
         this.setInLS(this.dictionaryKey, gdd);
     }
 
-    uploadExtensionData(data: any): void {
-        chrome.storage.local.clear(() => {
-            chrome.storage.local.set(data);
-        });
+    async uploadExtensionData(data: any): Promise<boolean> {
+        await chrome.storage.local.clear();
+        await chrome.storage.local.set(data);
+        return this.getCurrentActivation();
     }
 
     /**


### PR DESCRIPTION
Added code to update context menu activation option when activation change due to importing extension data or by pressing toggle button in popup.