### PR TITLE
feat: add custom highlight coloring

### DIFF
--- a/public/cross-page-assets/highlight-style.css
+++ b/public/cross-page-assets/highlight-style.css
@@ -1,5 +1,6 @@
 .vf-highlighted {
     background-color: #ffff01 !important;
+    color: #000000 !important;
     display: inline !important;
 }
 

--- a/public/cross-page-assets/highlight-style.css
+++ b/public/cross-page-assets/highlight-style.css
@@ -1,6 +1,6 @@
 .vf-highlighted {
-    background-color: #ffff01 !important;
-    color: #000000 !important;
+    background-color: #ffff01;
+    color: #000000;
     display: inline !important;
 }
 

--- a/src/background-scripts/contextmenu.ts
+++ b/src/background-scripts/contextmenu.ts
@@ -6,7 +6,7 @@ export class ContextMenuManager {
     static readonly activationID = 'activation';
     static readonly quizID = 'quiz';
     static readonly deleteHighlightsID = "delete_hilight";
-    static readonly changeHighlightStyling = 'highlight-style';
+    static readonly changeHighlightStylingID = 'highlight-style';
 
     static readonly activateActivationCMTitle = '🟢   Activate';
     static readonly deactivateActivationCMTitle = '🔴  Deactivate';
@@ -70,7 +70,7 @@ export class ContextMenuManager {
             contexts: ["all"]
           });
           chrome.contextMenus.create({
-            id: ContextMenuManager.changeHighlightStyling,
+            id: ContextMenuManager.changeHighlightStylingID,
             title: ContextMenuManager.changeHighlightStyleingTitle,
             contexts: ["all"],
           });
@@ -140,7 +140,7 @@ export class ContextMenuManager {
                     chrome.tabs.sendMessage(tab.id, message);
                     break;
                 }
-                case ContextMenuManager.changeHighlightStyleingTitle: {
+                case ContextMenuManager.changeHighlightStylingID: {
                     // notify triggering tab that it needs to change highlight style
                     if (tab === undefined || tab.id === undefined) {
                         console.error('highlight change triggered without active tab')

--- a/src/background-scripts/contextmenu.ts
+++ b/src/background-scripts/contextmenu.ts
@@ -6,11 +6,13 @@ export class ContextMenuManager {
     static readonly activationID = 'activation';
     static readonly quizID = 'quiz';
     static readonly deleteHighlightsID = "delete_hilight";
+    static readonly changeHighlightStyling = 'highlight-style';
 
     static readonly activateActivationCMTitle = '🟢   Activate';
     static readonly deactivateActivationCMTitle = '🔴  Deactivate';
     static readonly quizCMTitle = "🧠  Quiz";
     static readonly deleteHighlightCMTitle = '❌  Delete Hilighted Text';
+    static readonly changeHighlightStyleingTitle = '🖌 Change Highlight Style';
 
     setUpCMsCalled: boolean;  // true iff context menus have already been set up
     storage: NonVolatileBrowserStorage;
@@ -68,6 +70,16 @@ export class ContextMenuManager {
             contexts: ["all"]
           });
           chrome.contextMenus.create({
+            id: ContextMenuManager.changeHighlightStyling,
+            title: ContextMenuManager.changeHighlightStyleingTitle,
+            contexts: ["all"],
+          });
+          chrome.contextMenus.create({
+            id: "separator-3",
+            type: "separator",
+            contexts: ["all"]
+          });
+          chrome.contextMenus.create({
             id: ContextMenuManager.deleteHighlightsID,
             title: ContextMenuManager.deleteHighlightCMTitle,
             contexts: ["all"],
@@ -117,13 +129,25 @@ export class ContextMenuManager {
                     break;
                 }
                 case ContextMenuManager.quizID: {
-                    // notify trigerring tab that it needs to delete something
+                    // notify triggering tab that it needs to delete something
                     if (tab === undefined || tab.id === undefined) {
-                        console.error('quiz trigerred wtihout valid tab')
+                        console.error('quiz triggered without active tab')
                         break;
                     }
                     let message: CSMessage = {
                         messageType: CSMessageType.StartQuiz,
+                    }
+                    chrome.tabs.sendMessage(tab.id, message);
+                    break;
+                }
+                case ContextMenuManager.changeHighlightStyleingTitle: {
+                    // notify triggering tab that it needs to change highlight style
+                    if (tab === undefined || tab.id === undefined) {
+                        console.error('highlight change triggered without active tab')
+                        break;
+                    }
+                    let message: CSMessage = {
+                        messageType: CSMessageType.ChangeHighlightStyle,
                     }
                     chrome.tabs.sendMessage(tab.id, message);
                     break;

--- a/src/content-scripts/highlight-manager.ts
+++ b/src/content-scripts/highlight-manager.ts
@@ -1,5 +1,5 @@
 import { BSMessage, BSMessageType } from '../utils/background-script-communication';
-import { applyStylingOptions, HighlightOptions, SiteData, Word } from '../utils/models'
+import { HighlightOptions, SiteData, Word } from '../utils/models'
 import { highlightRecovery } from './highlight-recovery';
 import { defineWord, HILIGHT_CLASS, HILIGHT_CLASS_HOVER, isHighlightElement, isHighlightNode, isTextNode, nodeToTreePath, nodPathToNode } from './utils';
 
@@ -181,8 +181,23 @@ class Highlight {
      */
     syncIdsOfHighlightNodes() {
         for (let i = 0; i < this.highlightNodes.length; i++) {
-            let node = this.highlightNodes[i] as Element;
+            const node = this.highlightNodes[i] as Element;
             node.setAttribute("id", `word_${this.id}_${i}`);
+        }
+    }
+
+    /**
+     * Change styling of DOM nodes covered by this highlight element.
+     * 
+     * @param highlightStyleOptions CSS styling to apply to highlight DOM element.
+     */
+    applyStyle(highlightStyleOptions: HighlightOptions): void {
+        const fontColor = highlightStyleOptions.fontColor;
+        const bgColor = highlightStyleOptions.backgroundColor;
+        for (let i = 0; i < this.highlightNodes.length; i++) {
+            const node = this.highlightNodes[i] as HTMLElement;
+            node.style.color = fontColor;
+            node.style.backgroundColor = bgColor;
         }
     }
 
@@ -345,7 +360,10 @@ export class HighlightsManager {
      */
     applyHighlightStyle() {
         if (this.highlightStyleOptions) {
-            applyStylingOptions(this.highlightStyleOptions);
+            for (let i = 0; i < this.highlights.length; i++) {
+                const highlight = this.highlights[i];
+                highlight.applyStyle(this.highlightStyleOptions);
+            }
         }
     }
 
@@ -360,6 +378,9 @@ export class HighlightsManager {
         let highlightForWord = new Highlight(word, this.highlights.length, this);
         this.insertHighlightData(highlightForWord);
         highlightForWord.highlightWord();
+        if (this.highlightStyleOptions) {
+            highlightForWord.applyStyle(this.highlightStyleOptions);
+        }
     }
 
     /**
@@ -397,6 +418,8 @@ export class HighlightsManager {
 
             data.wordEntries = this.getWordEntries();
             return false;
+        } finally {
+            this.applyHighlightStyle();
         }
     }
     

--- a/src/content-scripts/highlight-manager.ts
+++ b/src/content-scripts/highlight-manager.ts
@@ -1,5 +1,5 @@
 import { BSMessage, BSMessageType } from '../utils/background-script-communication';
-import { SiteData, Word } from '../utils/models'
+import { applyStylingOptions, HighlightOptions, SiteData, Word } from '../utils/models'
 import { highlightRecovery } from './highlight-recovery';
 import { defineWord, HILIGHT_CLASS, HILIGHT_CLASS_HOVER, isHighlightElement, isHighlightNode, isTextNode, nodeToTreePath, nodPathToNode } from './utils';
 
@@ -307,10 +307,46 @@ export class HighlightsManager {
     highlights: Highlight[];
     // Number whose ID is the last highlight node to have been hovered over
     indexToDelete: number;
+    // styling options for highlighting
+    highlightStyleOptions?: HighlightOptions;
 
     constructor() {
         this.highlights = [];
         this.indexToDelete = -1;
+    }
+
+    /**
+     * Sets the style options of highlights based on SiteData
+     *
+     * @param siteData Site data for current website
+     */
+     setStyleOptionsFromSiteData(siteData: SiteData): void {
+        this.highlightStyleOptions = siteData.highlightOptions;
+    }
+
+    /**
+     * Sets the style options of highlights
+     *
+     * @param opts Highlight styling optoins to use
+     */
+     setStyleOptions(opts: HighlightOptions): void {
+        this.highlightStyleOptions = opts;
+    }
+
+    /**
+     * Gets the style options of highlights based on SiteData
+     */
+    getStyleOptions(): HighlightOptions | undefined {
+        return this.highlightStyleOptions;
+    }
+
+    /**
+     * If highlight style is defined, changes highlight class style to provided operation.
+     */
+    applyHighlightStyle() {
+        if (this.highlightStyleOptions) {
+            applyStylingOptions(this.highlightStyleOptions);
+        }
     }
 
     /**

--- a/src/content-scripts/main.ts
+++ b/src/content-scripts/main.ts
@@ -225,6 +225,10 @@ function saveData(hm: HighlightsManager, missingWords: string[]): void {
         wordEntries: wordsHighlighted,
         missingWords: missingWords
     }
+    const styleOpt = hm.getStyleOptions();
+    if (styleOpt) {
+        data.highlightOptions = styleOpt;
+    }
 
     let saveMessage: BSMessage = {
         messageType: BSMessageType.StorePageData,
@@ -257,8 +261,6 @@ const previousOnMouseUp = document.onmouseup; // on mouse up value before extens
     chrome.runtime.sendMessage(getSDRequest, 
         (data: SiteData) => { 
             highlightManager.setStyleOptionsFromSiteData(data);
-            highlightManager.applyHighlightStyle();
-
             const neededRehighlight = !highlightManager.highlightAllData(data);
             for (let i = 0; i < data.missingWords.length; i++) {
                 missingWords.push(data.missingWords[i]);
@@ -333,13 +335,14 @@ function handler(request: any): void {
         case CSMessageType.ChangeHighlightStyle: {
             let highlightOptions  = highlightManager.getStyleOptions();
             if (isHighlightLight(highlightOptions)) {
-                highlightOptions = enforceExplicityLightMode(highlightOptions);
-            } else {
                 highlightOptions = enforceExplicityDarkMode(highlightOptions);
+            } else {
+                highlightOptions = enforceExplicityLightMode(highlightOptions);
             }
             highlightManager.setStyleOptions(highlightOptions);
             highlightManager.applyHighlightStyle();
             saveData(highlightManager, missingWords);
+            break;
         }
         default: {
             console.log(`CONTENT_REQUEST UNKNOWN: ${request.messageType}`);

--- a/src/utils/content-script-communication.ts
+++ b/src/utils/content-script-communication.ts
@@ -6,6 +6,7 @@ export enum CSMessageType {
     ActivationStateChange,
     DeleteChosenHighlight,
     StartQuiz,
+    ChangeHighlightStyle,
 }
 
 /**

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -13,7 +13,7 @@ export interface Word {
 }
 
 /**
- * Creats Word object from 
+ * Creates Word object from
  * 
  * @param w text of Word interface
  * @param startOffset 
@@ -31,7 +31,15 @@ export function wordFromComponents(w: string, startOffset: number, endOffset: nu
 }
 
 /**
- * Representation of all data asociated with specfic web URL 
+ * Includes data used to change highlight styling
+ */
+export interface HighlightOptions {
+    fontColor: string;
+    backgroundColor: string;
+}
+
+/**
+ * Representation of all data associated with specific web URL
  */
 export interface SiteData {
     // list of texts in current site that were last highlighted. ID of highlighted text 
@@ -39,6 +47,59 @@ export interface SiteData {
     wordEntries: Word[];
     // list of words to look for in site; e.g. words that we expected to find but did not
     missingWords: string[];
+    // generic field for shit
+    highlightOptions?: HighlightOptions;
+}
+
+/**
+ * @param highlightOptions 
+ * @returns true if options corresponds to light-mode, false otherwise
+ */
+export function isHighlightLight(highlightOptions?: HighlightOptions): boolean {
+    return highlightOptions === undefined || (
+        highlightOptions.fontColor === '#000000'
+        && highlightOptions.backgroundColor === '#ffff01'
+        );
+}
+
+/**
+ * Change highlights for a light webpage (yellow background with black text)
+ * 
+ * @param options current style options for a webpage
+ */
+export function enforceExplicityLightMode(options?: HighlightOptions): HighlightOptions {
+    return setSiteDataHighlightOptions(options, '#ffff01', '#000000');
+}
+
+/**
+ * Change highlights for a dark webpage (blue background with white text)
+ *
+ * @param options current style options
+ */
+export function enforceExplicityDarkMode(options?: HighlightOptions): HighlightOptions {
+    return setSiteDataHighlightOptions(options, '#0008fa', '#ffffff');
+}
+
+/**
+ * Set style options for background and font color for highlighted text.
+ *
+ * @param options 
+ * @param backgroundColor 
+ * @param fontColor 
+ */
+function setSiteDataHighlightOptions(options: HighlightOptions | undefined, 
+    backgroundColor: string, fontColor: string): HighlightOptions {
+        if (!options) {
+            return {
+                fontColor: fontColor,
+                backgroundColor: backgroundColor
+            };
+        } else {
+            options.backgroundColor = backgroundColor;
+            options.fontColor = fontColor;
+            return options;
+        }
+    }
 }
 
 export function isEmpty(data: SiteData): boolean {
@@ -95,4 +156,37 @@ export interface GlobalDictionaryData {
 export function getLanguages(dc: GlobalDictionaryData): string[] {
     let mapping: SubjectToDictsMapping = dc.languagesToResources;
     return Object.getOwnPropertyNames(mapping);
+}
+
+/**
+ * Modifies HighlightOptions to contain whatever changes are requested
+ * 
+ * Assumes that highlight-style.css has been injected into this webpage
+ * 
+ * @param highlightOptions highlight options to apply
+ */
+export function applyStylingOptions(highlightOptions: HighlightOptions): void {
+    const fontColor = highlightOptions.fontColor
+    const backgroundColor = highlightOptions.backgroundColor
+
+    for (let i = 0; i < document.styleSheets.length; i++) {
+        let style = document.styleSheets[i];
+        if (style === null) {
+            continue;
+        }
+
+        const rules = style.cssRules;
+        for (let j = 0; j < rules.length; j++) {
+            let regla = rules[j];
+            if (!(regla instanceof CSSStyleRule)) {
+                continue;
+            }
+
+            if (regla.selectorText === '.vf-highlighted') {
+                regla.style.color = fontColor;
+                regla.style.backgroundColor = backgroundColor;
+                return;
+            }
+        }
+    }
 }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -32,6 +32,9 @@ export function wordFromComponents(w: string, startOffset: number, endOffset: nu
 
 /**
  * Includes data used to change highlight styling
+ * 
+ * Important implementation limitation of feature described here:
+ * https://betterprogramming.pub/how-to-fix-the-failed-to-read-the-cssrules-property-from-cssstylesheet-error-431d84e4a139
  */
 export interface HighlightOptions {
     fontColor: string;
@@ -87,18 +90,16 @@ export function enforceExplicityDarkMode(options?: HighlightOptions): HighlightO
  * @param backgroundColor 
  * @param fontColor 
  */
-function setSiteDataHighlightOptions(options: HighlightOptions | undefined, 
-    backgroundColor: string, fontColor: string): HighlightOptions {
-        if (!options) {
-            return {
-                fontColor: fontColor,
-                backgroundColor: backgroundColor
-            };
-        } else {
-            options.backgroundColor = backgroundColor;
-            options.fontColor = fontColor;
-            return options;
-        }
+function setSiteDataHighlightOptions(options: HighlightOptions | undefined, backgroundColor: string, fontColor: string): HighlightOptions {
+    if (!options) {
+        return {
+            fontColor: fontColor,
+            backgroundColor: backgroundColor
+        };
+    } else {
+        options.backgroundColor = backgroundColor;
+        options.fontColor = fontColor;
+        return options;
     }
 }
 
@@ -156,37 +157,4 @@ export interface GlobalDictionaryData {
 export function getLanguages(dc: GlobalDictionaryData): string[] {
     let mapping: SubjectToDictsMapping = dc.languagesToResources;
     return Object.getOwnPropertyNames(mapping);
-}
-
-/**
- * Modifies HighlightOptions to contain whatever changes are requested
- * 
- * Assumes that highlight-style.css has been injected into this webpage
- * 
- * @param highlightOptions highlight options to apply
- */
-export function applyStylingOptions(highlightOptions: HighlightOptions): void {
-    const fontColor = highlightOptions.fontColor
-    const backgroundColor = highlightOptions.backgroundColor
-
-    for (let i = 0; i < document.styleSheets.length; i++) {
-        let style = document.styleSheets[i];
-        if (style === null) {
-            continue;
-        }
-
-        const rules = style.cssRules;
-        for (let j = 0; j < rules.length; j++) {
-            let regla = rules[j];
-            if (!(regla instanceof CSSStyleRule)) {
-                continue;
-            }
-
-            if (regla.selectorText === '.vf-highlighted') {
-                regla.style.color = fontColor;
-                regla.style.backgroundColor = backgroundColor;
-                return;
-            }
-        }
-    }
 }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -35,6 +35,7 @@ export function wordFromComponents(w: string, startOffset: number, endOffset: nu
  * 
  * Important implementation limitation of feature described here:
  * https://betterprogramming.pub/how-to-fix-the-failed-to-read-the-cssrules-property-from-cssstylesheet-error-431d84e4a139
+ * https://stackoverflow.com/questions/49993633/uncaught-domexception-failed-to-read-the-cssrules-property
  */
 export interface HighlightOptions {
     fontColor: string;


### PR DESCRIPTION
* Added general capability to modify background and font colors for highlighted texts for a specific page and storing this data
* Added functionality for storing 2 style-option combinations: yellow-background-black-letters and blue-background-white-letters
