### PR TITLE
fix: restart indexeddb issues

### DIFF
--- a/src/background-scripts/indexed-db-nv-storage.test.ts
+++ b/src/background-scripts/indexed-db-nv-storage.test.ts
@@ -1131,6 +1131,66 @@ describe('IndexedDBStorage SiteDataStorage', () => {
                 expect(Object.keys(data)).toHaveLength(3);
             }
         ],
+        [
+            'getPageData',
+            async (dao: IndexedDBStorage) => {
+                const url = 'https://www.articles.fake.net/articles/456701';
+                const wordEntriesExpected =  [
+                    {
+                        word: 'manzana',
+                        startOffset: 33,
+                        endOffset: 44,
+                        nodePath: [[9,6,3,0], [10,6,3,0]]
+                    },
+                    {
+                        word: 'banana',
+                        startOffset: 45,
+                        endOffset: 12,
+                        nodePath: [[9,6,3,0], [9,7,3,0]]
+                    }
+                ];
+                const storeData = await dao.getPageData(url);
+                expect(storeData.missingWords).toEqual([]);
+                expect(storeData.wordEntries).toEqual(wordEntriesExpected);
+
+            }
+        ],
+        [
+            'storePageData',
+            async (dao: IndexedDBStorage) => {
+                const data =  { 
+                    wordEntries: [
+                        {
+                            word: 'comida',
+                            startOffset: 0,
+                            endOffset: 13,
+                            nodePath: [[9,6,3,0]]
+                        }
+                    ], 
+                    missingWords: ["foo", "bar"]
+                };
+                await dao.storePageData(data,'https://www.foobar.com/yahoo');
+                const storeData = await dao.getPageData('https://www.foobar.com/yahoo');
+                expect(storeData).toEqual(data);
+                const sites = await dao.getAllPageUrls();
+                expect(sites).toHaveLength(4);
+            }
+        ],
+        [
+            'removePageData',
+            async (dao: IndexedDBStorage) => {
+                await dao.removePageData('https://www.articles.fake.net/articles/334567');
+                const storeData = await dao.getPageData('https://www.foobar.com/yahoo');
+                const emptySiteData: SiteData = {
+                    wordEntries: [],
+                    missingWords: []
+                };
+                expect(storeData).toEqual(emptySiteData);
+                const sites = await dao.getAllPageUrls();
+                expect(sites).toHaveLength(2);
+            }
+
+        ]
     ])('%s async test', async (name: string, executeQuery: queryFunction) => {
         //jest.setTimeout(10000);  // Does not work in in async tests
         const dataToStore: any = {

--- a/src/background-scripts/indexed-db-nv-storage.test.ts
+++ b/src/background-scripts/indexed-db-nv-storage.test.ts
@@ -1189,7 +1189,44 @@ describe('IndexedDBStorage SiteDataStorage', () => {
                 const sites = await dao.getAllPageUrls();
                 expect(sites).toHaveLength(2);
             }
+        ],
+        [
+            'getSeeSiteDataOfDomain',
+            async (dao: IndexedDBStorage) => {
+                let data: SeeSiteData[] = await dao.getSeeSiteDataOfDomain('https://www.articles.fake.net');
+                expect(data).toHaveLength(2);
+                data = await dao.getSeeSiteDataOfDomain('https://www.articles.net');
+                expect(data).toHaveLength(1);
+            }
+        ],
+        [
+            'uploadExtensionData',
+            async (dao: IndexedDBStorage) => {
+                const dataToStore = {
+                    'http://rettiwt.com/articles/334567': { 
+                        schemeAndHost: 'http://rettiwt.com',
+                        urlPath: '/articles/334567',
+                        wordEntries: [
+                            {
+                                word: 'comida',
+                                startOffset: 0,
+                                endOffset: 13,
+                                nodePath: [[9,6,3,0]]
+                            }
+                        ], 
+                        missingWords: ["foo", "bar"]
+                    },
+                };
+                const succeeded: boolean = await dao.uploadExtensionData(dataToStore);
+                expect(succeeded).toBeTruthy();
 
+                let data: SeeSiteData[] = await dao.getSeeSiteDataOfDomain('https://www.articles.fake.net');
+                expect(data).toHaveLength(0);
+                data = await dao.getSeeSiteDataOfDomain('https://www.articles.net');
+                expect(data).toHaveLength(0);
+                data = await dao.getSeeSiteDataOfDomain('http://rettiwt.com');
+                expect(data).toHaveLength(1);
+            }
         ]
     ])('%s async test', async (name: string, executeQuery: queryFunction) => {
         //jest.setTimeout(10000);  // Does not work in in async tests

--- a/src/background-scripts/indexed-db-nv-storage.ts
+++ b/src/background-scripts/indexed-db-nv-storage.ts
@@ -81,7 +81,8 @@ export class IndexedDBStorage implements NonVolatileBrowserStorage {
     /**
      * For testing use only! Executes {@link setUp} function, but with some delay
      * 
-     * @param oldStorage 
+     * @param waitTimeMS time in milliseconds to wait before calling {@link setUp}
+     * @param oldStorage LocalStorage object previously used to hold SiteData 
      */
     async setUpTestFunction(waitTimeMS: number, oldStorage?: LocalStorage): Promise<IDBDatabase> {
         this.dbPromise = new Promise<IDBDatabase>(async (resolve, reject) => {

--- a/src/background-scripts/indexed-db-nv-storage.ts
+++ b/src/background-scripts/indexed-db-nv-storage.ts
@@ -77,6 +77,21 @@ export class IndexedDBStorage implements NonVolatileBrowserStorage {
 
         return this.dbPromise;
     }
+
+    /**
+     * For testing use only! Executes {@link setUp} function, but with some delay
+     * 
+     * @param oldStorage 
+     */
+    async setUpTestFunction(waitTimeMS: number, oldStorage?: LocalStorage): Promise<IDBDatabase> {
+        this.dbPromise = new Promise<IDBDatabase>(async (resolve, reject) => {
+            await new Promise(resolve => setTimeout( resolve, waitTimeMS));
+            const result: IDBDatabase = await this.setUp(oldStorage);
+            resolve(result);
+        });
+        return this.dbPromise;
+       
+    }
     
     getPageData(url: string): Promise<SiteData> {
         const query = (db: IDBDatabase): Promise<SiteData> => {


### PR DESCRIPTION
Introduced new implementation of query functions for IndexedDB storage DAO. Instead of failing if database connection is not established, we instead wait for the setUp promise to complete before attempting to evaluate the query. 

This was needed because of Chrome's policy of restarting extensions' background service-worker after 5 minutes of inactivity, which introduced stability issues.