### PR TITLE
feat: add highlight configuration

### DIFF
--- a/public/web_pages/see-sites.html
+++ b/public/web_pages/see-sites.html
@@ -163,6 +163,13 @@
                 <div class="title">Labels</div>
                 <div id="labels-list-section" class="site-data-section word-grid"></div>
             </div>
+            <div class="sitedata-section" id="highlight-colors-section">
+                <div class="title">Highlight Settings</div>
+                <label for="bg-color">Background color:</label>
+                <input type="color" id="bg-color" name="bg-color" value="#ff0000">
+                <label for="font-color">Font color:</label>
+                <input type="color" id="font-color" name="font-color" value="#ff0000">
+            </div>
             <div class="sitedata-section" id="present-words-section">
                 <div class="title">Present Words</div>
                 <div id="present-words" class="site-data-section word-grid"></div>

--- a/public/web_pages/see-sites.html
+++ b/public/web_pages/see-sites.html
@@ -108,6 +108,14 @@
             display: inline-block;
             width: 175px;
         }
+        label.color-input {
+            margin-top: 5px;
+            margin-bottom: 5px;
+        }
+        input[type="color" i] {
+            width: 50px;
+            height: 20pt;
+        }
         #site-name-header {
             text-align: center;
             max-width: 32em;
@@ -165,10 +173,19 @@
             </div>
             <div class="sitedata-section" id="highlight-colors-section">
                 <div class="title">Highlight Settings</div>
-                <label for="bg-color">Background color:</label>
-                <input type="color" id="bg-color" name="bg-color" value="#ff0000">
-                <label for="font-color">Font color:</label>
-                <input type="color" id="font-color" name="font-color" value="#ff0000">
+                <div>
+                    <div>
+                        <label class="color-input" for="bg-color">Background color:</label>
+                        <input type="color" id="bg-color" name="bg-color" value="#ff0000">
+                    </div>
+                    <div>
+                        <label class="color-input" for="font-color">Font color:</label>
+                        <input type="color" id="font-color" name="font-color" value="#ff0000">
+                    </div>
+                </div>
+                <div style="display: flex;">
+                    <p style="border:solid; margin: auto; margin-top: 20px; padding: 8px;">See <span id=highlight-demo>example highlight</span> here.</p>
+                </div>
             </div>
             <div class="sitedata-section" id="present-words-section">
                 <div class="title">Present Words</div>

--- a/src/content-scripts/highlight-recovery.ts
+++ b/src/content-scripts/highlight-recovery.ts
@@ -411,7 +411,8 @@ function findMissingWords(root: Trie, textNodes: Node[], highlight: WordConsumer
             if (root.children.size === 0) {
                 return null;
             }
-            const totalNodesChange= endParent.childNodes.length - nodesOfEPPostHL;
+            const totalNodesChange = endParent.childNodes.length 
+                - nodesOfEPPostHL;
 
             // Update textNodes assumes that each highlight node always results in 3 new nodes being made to replace the one that was modified.
             // at parent level

--- a/src/page-scripts/edit-site-data.test.ts
+++ b/src/page-scripts/edit-site-data.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from 'fs';
+import { JSDOM } from "jsdom";
+import { SiteData } from '../utils/models';
+
+// Assumes npm test ran from repo root
+// Set up DOM before edite-site-data is imported so that constants point to real
+//   HTML elements
+const HTML_PAGE = './public/web_pages/see-sites.html'; 
+const PAGE_CONTENT: string = readFileSync(HTML_PAGE , 'utf-8');
+const MOCK_DOM: JSDOM = new JSDOM(PAGE_CONTENT);
+global.document = MOCK_DOM.window.document;
+global.Node = MOCK_DOM.window.Node;
+global.Range = MOCK_DOM.window.Range;
+global.DOMParser = MOCK_DOM.window.DOMParser;
+
+
+import { BACKGROUND_COLOR_INPUT, clearEditPageComponents, FONT_COLOR_INPUT, LABELS_LIST_SECTION, LABELS_SECTION, MISSING_WORDS_LIST_SECTION, PRESENT_WORDS_LIST_SECTION, setUpEditPage, SITE_NAME_HEADER } from './edit-site-data';
+
+describe('Scripts for Editting Site Data from Settings Page', () => {
+    test('test clearEditPageComponents', async () => {
+        const url = 'https://test0.com?test=standard-content';
+        const labels = ['platos-argentinos']
+        const sd: SiteData = {
+            title: 'Basic Test Everything Filled',
+            wordEntries: [
+                {
+                    word: 'vacio',
+                    startOffset: 0,
+                    endOffset: 5,
+                    nodePath: [[0,0,0]],
+                },
+            ],
+            missingWords: ['chimichurri'],
+            highlightOptions: {
+                fontColor: '#00FF00',
+                backgroundColor: '#FF00FF',
+            } 
+
+        };
+        const sdp = Promise.resolve(sd);
+        const ldp = Promise.resolve(labels);
+        await setUpEditPage(url, sdp, ldp);
+        expect(LABELS_SECTION.style.display).toBe('inline-block');
+        expect(LABELS_LIST_SECTION.childElementCount).toBe(1 + labels.length);
+        expect(MISSING_WORDS_LIST_SECTION.childElementCount)
+            .toBe(sd.missingWords.length);
+        expect(PRESENT_WORDS_LIST_SECTION.childElementCount)
+            .toBe(sd.wordEntries.length);
+
+        clearEditPageComponents();
+        expect(LABELS_SECTION.style.display).toBe('none');
+        expect(LABELS_LIST_SECTION.childElementCount).toBe(0);
+        expect(MISSING_WORDS_LIST_SECTION.childElementCount).toBe(0);
+        expect(PRESENT_WORDS_LIST_SECTION.childElementCount).toBe(0);
+    });
+    it.each([
+        [
+            'https://test0.com?test=standard-content',
+            {
+                title: 'Basic Test Everything Filled',
+                wordEntries: [
+                    {
+                        word: 'vacio',
+                        startOffset: 0,
+                        endOffset: 5,
+                        nodePath: [[0,0,0]],
+                    },
+                ],
+                missingWords: ['chimichurri'],
+                highlightOptions: {
+                    fontColor: '#000000',
+                    backgroundColor: '#FFFF00',
+                } 
+
+            },
+            ['platos-argentinos']
+        ],
+        [
+            'https://test0.com?test=standard-content',
+            {
+                title: 'Basic Test Everything Filled 2',
+                wordEntries: [
+                    {
+                        word: 'vacio',
+                        startOffset: 0,
+                        endOffset: 5,
+                        nodePath: [[0,0,0]],
+                    },
+                    {
+                        word: 'bife de chorizo',
+                        startOffset: 23,
+                        endOffset: 23+15,
+                        nodePath: [[0,0,0]],
+                    },
+                    {
+                        word: 'chorizo',
+                        startOffset: 30,
+                        endOffset: 30+7,
+                        nodePath: [[0,0,0]],
+                    },
+                    {
+                        word: 'mate',
+                        startOffset: 40,
+                        endOffset: 40+4,
+                        nodePath: [[0,0,0]],
+                    },
+
+                ],
+                missingWords: ['che', 'sangria', 'sal', 'pepinillo'],
+                highlightOptions: {
+                    fontColor: '#FF00FF',
+                    backgroundColor: '#00FF00',
+                } 
+            },
+            ['platos-argentinos', 'castellano', 'español', 'gol']
+        ],
+        [
+            'https://test0.com?test=totaly-empty',
+            {
+                wordEntries: [],
+                missingWords: [],
+            },
+            []
+        ],
+        [
+            'https://test1.com',
+            {
+                title: 'No Highlight options present at start',
+                wordEntries: [
+                    {
+                        word: 'vacio',
+                        startOffset: 0,
+                        endOffset: 5,
+                        nodePath: [[0,0,0]],
+                    },
+                ],
+                missingWords: ['chimichurri'],
+            },
+            ['platos-argentinos']
+        ],
+    ])('setUpEditPage', async (url: string, siteData: SiteData, labels: string[]) => {
+        const sdp = Promise.resolve(siteData);
+        const ldp = Promise.resolve(labels);
+        clearEditPageComponents();
+        await setUpEditPage(url, sdp, ldp)
+
+        if (siteData.highlightOptions === undefined) {
+            siteData.highlightOptions = {
+                backgroundColor: '#ffff01',
+                fontColor: '#000000',
+            };
+        }
+        expect(BACKGROUND_COLOR_INPUT.value.toLowerCase())
+            .toBe(siteData.highlightOptions.backgroundColor.toLowerCase());
+        expect(FONT_COLOR_INPUT.value.toLowerCase())
+            .toBe(siteData.highlightOptions.fontColor.toLowerCase());
+        expect(SITE_NAME_HEADER.textContent)
+            .toBe(siteData.title !== undefined ? siteData.title : url);
+        // 1 accounts for the input element
+        expect(LABELS_LIST_SECTION.childElementCount).toBe(1 + labels.length);
+        expect(MISSING_WORDS_LIST_SECTION.childElementCount)
+            .toBe(siteData.missingWords.length);
+        expect(PRESENT_WORDS_LIST_SECTION.childElementCount)
+            .toBe(siteData.wordEntries.length);
+
+        expect(LABELS_SECTION.style.display).toBe('inline-block');
+   });
+});
+

--- a/src/page-scripts/edit-site-data.test.ts
+++ b/src/page-scripts/edit-site-data.test.ts
@@ -165,5 +165,7 @@ describe('Scripts for Editting Site Data from Settings Page', () => {
 
         expect(LABELS_SECTION.style.display).toBe('inline-block');
    });
+
+   // TODO: add unit tests for changing highlight text content
 });
 

--- a/src/page-scripts/edit-site-data.ts
+++ b/src/page-scripts/edit-site-data.ts
@@ -3,13 +3,13 @@ import { BSMessage, BSMessageType } from "../utils/background-script-communicati
 import { HighlightOptions, SiteData } from "../utils/models";
 
 
-const SITE_NAME_HEADER= document.getElementById('site-name-header') as HTMLElement;
-const LABELS_LIST_SECTION = document.getElementById('labels-list-section') as HTMLDivElement;
-const MISSING_WORDS_LIST_SECTION = document.getElementById('missing-words') as HTMLDivElement;
-const PRESENT_WORDS_LIST_SECTION = document.getElementById('present-words') as HTMLDivElement;
+export const SITE_NAME_HEADER= document.getElementById('site-name-header') as HTMLElement;
+export const LABELS_LIST_SECTION = document.getElementById('labels-list-section') as HTMLDivElement;
+export const MISSING_WORDS_LIST_SECTION = document.getElementById('missing-words') as HTMLDivElement;
+export const PRESENT_WORDS_LIST_SECTION = document.getElementById('present-words') as HTMLDivElement;
 
-const LABELS_SECTION = document.getElementById('labels-section') as HTMLDivElement;
-const HIGHLIGHT_COLORS_SECTION = document
+export const LABELS_SECTION = document.getElementById('labels-section') as HTMLDivElement;
+export const HIGHLIGHT_COLORS_SECTION = document
     .getElementById('highlight-colors-section') as HTMLDivElement;
 export const BACKGROUND_COLOR_INPUT = document
     .getElementById('bg-color') as HTMLInputElement;

--- a/src/page-scripts/edit-site-data.ts
+++ b/src/page-scripts/edit-site-data.ts
@@ -15,6 +15,9 @@ export const BACKGROUND_COLOR_INPUT = document
     .getElementById('bg-color') as HTMLInputElement;
 export const FONT_COLOR_INPUT = document
     .getElementById('font-color') as HTMLInputElement;
+export const HIGHLIGHT_DEMO = document
+    .getElementById('highlight-demo') as HTMLDivElement;
+
 
 const MISSING_WORDS_SECTION = document.getElementById('missing-words-section') as HTMLDivElement;
 const PRESENT_WORDS_SECTION = document.getElementById('present-words-section') as HTMLDivElement;
@@ -136,6 +139,8 @@ async function populateSiteData(url: string,
         FONT_COLOR_INPUT.value = ogFontColor; 
         FONT_COLOR_INPUT.onchange = () => 
             updateHighlightOpts(url, siteData);
+        HIGHLIGHT_DEMO.style.backgroundColor = ogBGColor;
+        HIGHLIGHT_DEMO.style.color = ogFontColor;
 }
 
 function updateHighlightOpts(url: string, siteData: SiteData): void {
@@ -145,6 +150,8 @@ function updateHighlightOpts(url: string, siteData: SiteData): void {
     };
     siteData.highlightOptions = newHighlights;
     saveSiteData(url, siteData);
+    HIGHLIGHT_DEMO.style.backgroundColor = newHighlights.backgroundColor;
+    HIGHLIGHT_DEMO.style.color = newHighlights.fontColor;
 }
 
 function saveSiteData(url: string, siteData: SiteData): void {

--- a/src/page-scripts/edit-site-data.ts
+++ b/src/page-scripts/edit-site-data.ts
@@ -1,6 +1,6 @@
 import { QuizManager } from "../content-scripts/quiz";
 import { BSMessage, BSMessageType } from "../utils/background-script-communication";
-import { SiteData } from "../utils/models";
+import { HighlightOptions, SiteData } from "../utils/models";
 
 
 const SITE_NAME_HEADER= document.getElementById('site-name-header') as HTMLElement;
@@ -9,6 +9,13 @@ const MISSING_WORDS_LIST_SECTION = document.getElementById('missing-words') as H
 const PRESENT_WORDS_LIST_SECTION = document.getElementById('present-words') as HTMLDivElement;
 
 const LABELS_SECTION = document.getElementById('labels-section') as HTMLDivElement;
+const HIGHLIGHT_COLORS_SECTION = document
+    .getElementById('highlight-colors-section') as HTMLDivElement;
+export const BACKGROUND_COLOR_INPUT = document
+    .getElementById('bg-color') as HTMLInputElement;
+export const FONT_COLOR_INPUT = document
+    .getElementById('font-color') as HTMLInputElement;
+
 const MISSING_WORDS_SECTION = document.getElementById('missing-words-section') as HTMLDivElement;
 const PRESENT_WORDS_SECTION = document.getElementById('present-words-section') as HTMLDivElement;
 
@@ -17,6 +24,7 @@ export const QUIZ_BUTTON = document.getElementById('quiz-button') as HTMLElement
 
 export function setUpEditPage(url: string, siteDataPromise: Promise<SiteData>,
     labelsPromise: Promise<string[]>): void {
+        HIGHLIGHT_COLORS_SECTION.style.display = 'inline-block';
         LABELS_SECTION.style.display = 'inline-block';
         PRESENT_WORDS_SECTION.style.display = 'inline-block';
         MISSING_WORDS_SECTION.style.display = 'inline-block';
@@ -30,6 +38,7 @@ export function clearEditPageComponents(): void {
     LABELS_LIST_SECTION.innerHTML = '';
     PRESENT_WORDS_LIST_SECTION.innerHTML = '';
     MISSING_WORDS_LIST_SECTION.innerHTML = '';
+    HIGHLIGHT_COLORS_SECTION.style.display = 'none';
     LABELS_SECTION.style.display = 'none';
     PRESENT_WORDS_SECTION.style.display = 'none';
     MISSING_WORDS_SECTION.style.display = 'none';
@@ -101,19 +110,41 @@ async function populateSiteData(url: string,
 
         const missingWordEntires: string[] = siteData.missingWords;
         const presentWordEntries: string[] = siteData.wordEntries.map((w) => w.word);
-        createTextEntries(presentWordEntries, 'present-words', siteData, (sd: SiteData, i) => {
-            sd.wordEntries.splice(i, 1);
-            saveSiteData(url, sd);
+        createTextEntries(presentWordEntries, 'present-words', siteData,
+            (sd: SiteData, i) => {
+                sd.wordEntries.splice(i, 1);
+                saveSiteData(url, sd);
         });
-        createTextEntries(missingWordEntires, 'missing-words', siteData, (sd: SiteData, i) => {
-            sd.missingWords.splice(i, 1);
-            saveSiteData(url, sd);
+        createTextEntries(missingWordEntires, 'missing-words', siteData,
+            (sd: SiteData, i) => {
+                sd.missingWords.splice(i, 1);
+                saveSiteData(url, sd);
         });
 
         const quizzer = new QuizManager();
-        QUIZ_BUTTON.addEventListener('click', () => {
+        QUIZ_BUTTON.onclick = () => {
             quizzer.loadQuizHTML(siteData);
-        });
+        };
+
+        const ogBGColor = siteData.highlightOptions?.backgroundColor === undefined
+            ? '#FFFF01' : siteData.highlightOptions?.backgroundColor;
+        BACKGROUND_COLOR_INPUT.value = ogBGColor;
+        BACKGROUND_COLOR_INPUT.onchange = () =>
+            updateHighlightOpts(url, siteData);
+        const ogFontColor = siteData.highlightOptions?.fontColor=== undefined
+            ? '#000000' : siteData.highlightOptions?.fontColor;
+        FONT_COLOR_INPUT.value = ogFontColor; 
+        FONT_COLOR_INPUT.onchange = () => 
+            updateHighlightOpts(url, siteData);
+}
+
+function updateHighlightOpts(url: string, siteData: SiteData): void {
+    const newHighlights: HighlightOptions = {
+        backgroundColor: BACKGROUND_COLOR_INPUT.value,
+        fontColor: FONT_COLOR_INPUT.value,
+    };
+    siteData.highlightOptions = newHighlights;
+    saveSiteData(url, siteData);
 }
 
 function saveSiteData(url: string, siteData: SiteData): void {


### PR DESCRIPTION
Expand capabilities of existing highlighting options so that users can customize the color of highlight block (background) and text used when highlighting a particular web page.